### PR TITLE
Enable guests to detect more than 64GB of memory

### DIFF
--- a/BhyvePkg/PlatformPei/MemDetect.c
+++ b/BhyvePkg/PlatformPei/MemDetect.c
@@ -35,6 +35,8 @@ Module Name:
 #include "Platform.h"
 #include "Cmos.h"
 
+UINT8 mPhysMemAddressWidth;
+
 STATIC
 UINTN
 GetSystemMemorySizeBelow4gb (
@@ -83,6 +85,109 @@ GetSystemMemorySizeAbove4gb (
   return LShiftU64 (Size, 16);
 }
 
+/**
+  Initialize the mPhysMemAddressWidth variable, based on guest RAM size.
+**/
+VOID
+AddressWidthInitialization (
+  VOID
+  )
+{
+  UINT64 FirstNonAddress;
+
+  //
+  // As guest-physical memory size grows, the permanent PEI RAM requirements
+  // are dominated by the identity-mapping page tables built by the DXE IPL.
+  // The DXL IPL keys off of the physical address bits advertized in the CPU
+  // HOB. To conserve memory, we calculate the minimum address width here.
+  //
+  FirstNonAddress      = BASE_4GB + GetSystemMemorySizeAbove4gb ();
+  mPhysMemAddressWidth = (UINT8)HighBitSet64 (FirstNonAddress);
+
+  //
+  // If FirstNonAddress is not an integral power of two, then we need an
+  // additional bit.
+  //
+  if ((FirstNonAddress & (FirstNonAddress - 1)) != 0) {
+    ++mPhysMemAddressWidth;
+  }
+
+  //
+  // The minimum address width is 36 (covers up to and excluding 64 GB, which
+  // is the maximum for Ia32 + PAE). The theoretical architecture maximum for
+  // X64 long mode is 52 bits, but the DXE IPL clamps that down to 48 bits. We
+  // can simply assert that here, since 48 bits are good enough for 256 TB.
+  //
+  if (mPhysMemAddressWidth <= 36) {
+    mPhysMemAddressWidth = 36;
+  }
+  ASSERT (mPhysMemAddressWidth <= 48);
+}
+
+
+/**
+  Calculate the cap for the permanent PEI memory.
+**/
+STATIC
+UINT32
+GetPeiMemoryCap (
+  VOID
+  )
+{
+  BOOLEAN Page1GSupport;
+  UINT32  RegEax;
+  UINT32  RegEdx;
+  UINT32  Pml4Entries;
+  UINT32  PdpEntries;
+  UINTN   TotalPages;
+
+  //
+  // If DXE is 32-bit, then just return the traditional 64 MB cap.
+  //
+#ifdef MDE_CPU_IA32
+  if (!FeaturePcdGet (PcdDxeIplSwitchToLongMode)) {
+    return SIZE_64MB;
+  }
+#endif
+
+  //
+  // Dependent on physical address width, PEI memory allocations can be
+  // dominated by the page tables built for 64-bit DXE. So we key the cap off
+  // of those. The code below is based on CreateIdentityMappingPageTables() in
+  // "MdeModulePkg/Core/DxeIplPeim/X64/VirtualMemory.c".
+  //
+  Page1GSupport = FALSE;
+  if (PcdGetBool (PcdUse1GPageTable)) {
+    AsmCpuid (0x80000000, &RegEax, NULL, NULL, NULL);
+    if (RegEax >= 0x80000001) {
+      AsmCpuid (0x80000001, NULL, NULL, NULL, &RegEdx);
+      if ((RegEdx & BIT26) != 0) {
+        Page1GSupport = TRUE;
+      }
+    }
+  }
+
+  if (mPhysMemAddressWidth <= 39) {
+    Pml4Entries = 1;
+    PdpEntries = 1 << (mPhysMemAddressWidth - 30);
+    ASSERT (PdpEntries <= 0x200);
+  } else {
+    Pml4Entries = 1 << (mPhysMemAddressWidth - 39);
+    ASSERT (Pml4Entries <= 0x200);
+    PdpEntries = 512;
+  }
+
+  TotalPages = Page1GSupport ? Pml4Entries + 1 :
+                               (PdpEntries + 1) * Pml4Entries + 1;
+  ASSERT (TotalPages <= 0x40201);
+
+  //
+  // Add 64 MB for miscellaneous allocations. Note that for
+  // mPhysMemAddressWidth values close to 36, the cap will actually be
+  // dominated by this increment.
+  //
+  return (UINT32)(EFI_PAGES_TO_SIZE (TotalPages) + SIZE_64MB);
+}
 
 /**
   Peform Memory Detection
@@ -99,6 +204,7 @@ MemDetect (
   UINT64                      MemorySize;
   UINT64                      LowerMemorySize;
   UINT64                      UpperMemorySize;
+  UINT32                      PeiMemoryCap;
 
   DEBUG ((EFI_D_ERROR, "MemDetect called\n"));
 
@@ -108,14 +214,18 @@ MemDetect (
   LowerMemorySize = GetSystemMemorySizeBelow4gb ();
   UpperMemorySize = GetSystemMemorySizeAbove4gb ();
 
+  PeiMemoryCap = GetPeiMemoryCap ();
+  DEBUG ((EFI_D_INFO, "%a: mPhysMemAddressWidth=%d PeiMemoryCap=%u KB\n",
+     __FUNCTION__, mPhysMemAddressWidth, PeiMemoryCap >> 10));
+
   //
   // Determine the range of memory to use during PEI
   //
   MemoryBase = PcdGet32 (PcdBhyveMemFvBase) + PcdGet32 (PcdBhyveMemFvSize);
   MemorySize = LowerMemorySize - MemoryBase;
-  if (MemorySize > SIZE_64MB) {
-    MemoryBase = LowerMemorySize - SIZE_64MB;
-    MemorySize = SIZE_64MB;
+  if (MemorySize > PeiMemoryCap) {
+    MemoryBase = LowerMemorySize - PeiMemoryCap;
+    MemorySize = PeiMemoryCap;
   }
 
   //

--- a/BhyvePkg/PlatformPei/Platform.c
+++ b/BhyvePkg/PlatformPei/Platform.c
@@ -225,7 +225,7 @@ MiscInitialization (
   //
   // Build the CPU hob with 36-bit addressing and 16-bits of IO space.
   //
-  BuildCpuHob (36, 16);
+  BuildCpuHob (mPhysMemAddressWidth, 16);
 
   //
   // If PMREGMISC/PMIOSE is set, assume the ACPI PMBA has been configured (for
@@ -342,6 +342,8 @@ InitializePlatform (
   DEBUG ((EFI_D_ERROR, "Platform PEIM Loaded\n"));
 
   DebugDumpCmos ();
+
+  AddressWidthInitialization ();
 
   TopOfMemory = MemDetect ();
 

--- a/BhyvePkg/PlatformPei/Platform.h
+++ b/BhyvePkg/PlatformPei/Platform.h
@@ -57,6 +57,11 @@ AddUntestedMemoryRangeHob (
   EFI_PHYSICAL_ADDRESS        MemoryLimit
   );
 
+VOID
+AddressWidthInitialization (
+  VOID
+  );
+
 EFI_PHYSICAL_ADDRESS
 MemDetect (
   VOID
@@ -66,5 +71,7 @@ EFI_STATUS
 PeiFvInitialization (
   VOID
   );
+
+extern UINT8 mPhysMemAddressWidth;
 
 #endif // _PLATFORM_PEI_H_INCLUDED_

--- a/BhyvePkg/PlatformPei/PlatformPei.inf
+++ b/BhyvePkg/PlatformPei/PlatformPei.inf
@@ -63,6 +63,8 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareSize
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableSize
   gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvStoreReserved
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDxeIplSwitchToLongMode
+  gEfiMdeModulePkgTokenSpaceGuid.PcdUse1GPageTable
   gUefiCpuPkgTokenSpaceGuid.PcdCpuLocalApicBaseAddress
 
 [Ppis]


### PR DESCRIPTION
This was a partial merge from UDK2015 Ovmf to enable Windows guests to
see more than 64GB of RAM.