### PR TITLE
- Enable OvmfPkg/VirtioScsiDxe.

### DIFF
--- a/BhyvePkg/BhyvePkgX64.dsc
+++ b/BhyvePkg/BhyvePkgX64.dsc
@@ -438,6 +438,7 @@
 
   OvmfPkg/VirtioPciDeviceDxe/VirtioPciDeviceDxe.inf
   OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
+  OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
   BhyvePkg/EmuVariableFvbRuntimeDxe/Fvb.inf {
     <LibraryClasses>
       PlatformFvbLib|BhyvePkg/Library/EmuVariableFvbLib/EmuVariableFvbLib.inf

--- a/BhyvePkg/BhyvePkgX64.fdf
+++ b/BhyvePkg/BhyvePkgX64.fdf
@@ -268,6 +268,7 @@ INF  PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcatRealTimeClockRuntimeDxe.inf
 
 INF  OvmfPkg/VirtioPciDeviceDxe/VirtioPciDeviceDxe.inf
 INF  OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
+INF  OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
 INF  BhyvePkg/EmuVariableFvbRuntimeDxe/Fvb.inf
 INF  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteDxe.inf
 


### PR DESCRIPTION
As part of the work to bring the virtio-scsi for bhyve: https://reviews.freebsd.org/D15276