### PR TITLE
OvmfPkg: use regular PCI bus enumeration for bhyve

### DIFF
--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -539,7 +539,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase64|0
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase|0
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase|0
-  gEfiMdeModulePkgTokenSpaceGuid.PcdPciDisableBusEnumeration|TRUE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPciDisableBusEnumeration|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdVideoHorizontalResolution|800
   gEfiMdeModulePkgTokenSpaceGuid.PcdVideoVerticalResolution|600
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiS3Enable|FALSE


### PR DESCRIPTION
With the initial import of bhyve functionality, I set
PcdPciDisableBusEnumeration = TRUE to follow the UDK2014.SP1 bhyve
firmware's behavior of using the no-enumeration PCI Dxes from
DuetPkg.

The enumeration disabled path is for Xen, which assumes that PCI
devices are configured in the way that Xen configures them, and
has various asserts to ensure this. Bhyve doesn't meet all the
expectations of this code path, specifically that all 64-bit
capable memory spaces are programmed at an address at or above 4G.

This prevents successfully booting with bhyve's nvme emulation, so
here we switch to using the PCI enumeration path like QEMU.